### PR TITLE
Testing without topic 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,2 @@
 # test-pr-repo-public
 Public testing
-
-
-


### PR DESCRIPTION
Seeing what happens when the repo contains only topics that block Testingmon (no topic3)
- sakuttomon was not assigned to this repo because topic3 is not a label